### PR TITLE
docs: improve guide to setup Cilium overlay on EKS

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -174,10 +174,20 @@ Install Cilium
           Kubernetes worker node than the ENI limit, but means that pod
           connectivity to resources outside the cluster (e.g., VMs in the VPC
           or AWS managed services) is masqueraded (i.e., SNAT) by Cilium to use
-          the VPC IP address of the Kubernetes worker node.  Excluding the
-          lines for ``eni.enabled=true``, ``ipam.mode=eni`` and
-          ``tunnel=disabled`` from the helm command will configure Cilium to
-          use overlay routing mode (which is the helm default).
+          the VPC IP address of the Kubernetes worker node. To set up Cilium 
+          overlay mode, follow the steps below:
+
+            1. Excluding the lines for ``eni.enabled=true``, ``ipam.mode=eni`` and 
+               ``tunnel=disabled`` from the helm command will configure Cilium to use 
+               overlay routing mode (which is the helm default).
+            2. Flush iptables rules added by VPC CNI
+
+               .. code-block:: shell-session
+               
+                  iptables -t nat -F AWS-SNAT-CHAIN-0 \\
+                     && iptables -t nat -F AWS-SNAT-CHAIN-1 \\
+                     && iptables -t nat -F AWS-CONNMARK-CHAIN-0 \\
+                     && iptables -t nat -F AWS-CONNMARK-CHAIN-1
 
          Some Linux distributions use a different interface naming convention.
          If you use masquerading with the option ``egressMasqueradeInterfaces=eth0``,


### PR DESCRIPTION
I've added several documentation steps to properly install Cilium overlay mode on EKS, since removing the `aws-node` daemonSet will not clear the following iptables rules and the leftover rules will affect routing and filtering decisions. 

```
-A PREROUTING -i eni+ -m comment --comment "AWS, outbound connections" -m state --state NEW -j AWS-CONNMARK-CHAIN-0
-A PREROUTING -m comment --comment "AWS, CONNMARK" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
-A POSTROUTING -m comment --comment "AWS SNAT CHAIN" -j AWS-SNAT-CHAIN-0
-A AWS-CONNMARK-CHAIN-0 ! -d 10.2.0.0/16 -m comment --comment "AWS CONNMARK CHAIN, VPC CIDR" -j AWS-CONNMARK-CHAIN-1
-A AWS-CONNMARK-CHAIN-1 -m comment --comment "AWS, CONNMARK" -j CONNMARK --set-xmark 0x80/0x80
-A AWS-SNAT-CHAIN-0 ! -d 10.2.0.0/16 -m comment --comment "AWS SNAT CHAIN" -j AWS-SNAT-CHAIN-1
-A AWS-SNAT-CHAIN-1 ! -o vlan+ -m comment --comment "AWS, SNAT" -m addrtype ! --dst-type LOCAL -j SNAT --to-source 10.2.2.245 --random-fully
```

Signed-off-by: Oliver Wang [a0924100192@gmail.com](mailto:a0924100192@gmail.com)
